### PR TITLE
memory: reduce BIG_CHUNK macro for better speed test

### DIFF
--- a/test/inc/header.h
+++ b/test/inc/header.h
@@ -3,6 +3,7 @@
 
 // #define _XOPEN_SOURCE 700
 #define _DEFAUTL_SOURCE
+#define BIG_CHUNKS (1 << 16) // 65Ko
 
 #include <unistd.h>
 #include <ctype.h>

--- a/test/src/memory/test_memchr.c
+++ b/test/src/memory/test_memchr.c
@@ -1,8 +1,5 @@
 #include "header.h"
 
-// 134Mo
-#define BIG_CHUNKS	(1 << 27)
-
 static char	c = 60; // '<'
 
 // HAS_ZERO

--- a/test/src/memory/test_memcpy.c
+++ b/test/src/memory/test_memcpy.c
@@ -1,8 +1,5 @@
 #include "header.h"
 
-// 134Mo
-#define BIG_CHUNKS	(1 << 27)
-
 static void	test_00_memcpy_AlignedSizeOfZero(void)
 {
 	size_t	buf_size = 20;

--- a/test/src/memory/test_memmove.c
+++ b/test/src/memory/test_memmove.c
@@ -1,8 +1,5 @@
 #include "header.h"
 
-// 134Mo
-#define BIG_CHUNKS	(1 << 27)
-
 static void	test_00_memmove_SizeZero(void)
 {
 	char	s1[20];

--- a/test/src/memory/test_memset.c
+++ b/test/src/memory/test_memset.c
@@ -1,8 +1,5 @@
 #include "header.h"
 
-// 134Mo
-#define BIG_CHUNKS	(1 << 27)
-
 static void	test_00_memset_AlignedLessThanWordSize(void)
 {
 	size_t	size = 16;


### PR DESCRIPTION
Les tests étaient trop long, surtout avec la lib **SANITIZE**. J'ai donc réduit la taille de macros.
